### PR TITLE
Expose launch template configs as plugin parameters

### DIFF
--- a/.humilis.ini
+++ b/.humilis.ini
@@ -7,4 +7,3 @@ aws_profile = default
 keys_dir = ~/.ssh
 s3prefix = humilis/firehose/
 aws_region = eu-west-1
-

--- a/humilis_batch/__init__.py
+++ b/humilis_batch/__init__.py
@@ -1,5 +1,5 @@
 """Humilis plug-in to deploy AWS Batch resources."""
 
 
-__version__ = "0.6.1"
+__version__ = "0.6.0"
 __author__ = "German Gomez-Herrero"

--- a/humilis_batch/__init__.py
+++ b/humilis_batch/__init__.py
@@ -1,5 +1,5 @@
 """Humilis plug-in to deploy AWS Batch resources."""
 
 
-__version__ = "0.5.1"
+__version__ = "0.6.1"
 __author__ = "German Gomez-Herrero"

--- a/humilis_batch/meta.yaml.j2
+++ b/humilis_batch/meta.yaml.j2
@@ -99,10 +99,6 @@ meta:
             description: The name of a SSH key to inject in the instances
             value:
 
-        has_launch_template:
-            description: Whether we should use a launch template
-            value: no
-
         user_data:
             description: The bas64 encoded user data to inject in the instances, use with has_launch_template set to yes
             value:

--- a/humilis_batch/meta.yaml.j2
+++ b/humilis_batch/meta.yaml.j2
@@ -98,3 +98,11 @@ meta:
         ec2_key_pair:
             description: The name of a SSH key to inject in the instances
             value:
+
+        has_launch_template:
+            description: Whether we should use a launch template
+            value: no
+
+        user_data:
+            description: The bas64 encoded user data to inject in the instances, use with has_launch_template set to yes
+            value:

--- a/humilis_batch/resources.yaml.j2
+++ b/humilis_batch/resources.yaml.j2
@@ -50,6 +50,7 @@ resources:
                                 - "ecr:BatchCheckLayerAvailability"
                                 - "ecr:GetDownloadUrlForLayer"
                                 - "ecr:BatchGetImage"
+                                - "secretsmanager:*"
                                 - "logs:CreateLogStream"
                                 - "logs:PutLogEvents"
                             "Resource": "*"
@@ -69,10 +70,10 @@ resources:
                 Statement:
                   -
                     Effect: "Allow"
-                    Principal: 
-                      Service: 
+                    Principal:
+                      Service:
                         - "batch.amazonaws.com"
-                    Action: 
+                    Action:
                       - "sts:AssumeRole"
             Path: "/"
             ManagedPolicyArns:
@@ -108,6 +109,17 @@ resources:
                   SourceSecurityGroupId: {{sg}}
                 {% endfor %}
             {% endif %}
+
+    {% if has_launch_template %}
+    LaunchTemplate:
+      Type: "AWS::EC2::LaunchTemplate"
+      Properties:
+        LaunchTemplateName: "{{__context.environment.name}}-{{__context.layer.name}}-{{__context.stage}}"
+        LaunchTemplateData:
+          {% if user_data %}
+          UserData: {{user_data}}
+          {% endif %}
+    {% endif %}
 
     ComputeEnvironment:
       Type: "AWS::Batch::ComputeEnvironment"
@@ -163,6 +175,12 @@ resources:
             Type: {{type}}
             {% if type == "SPOT" %}
             BidPercentage: {{bid_percentage}}
+            {% endif %}
+            {% if has_launch_template %}
+            LaunchTemplate:
+              LaunchTemplateId: {Ref: LaunchTemplate}
+              Version:
+                "Fn::GetAtt": ["LaunchTemplate", "LatestVersionNumber"]
             {% endif %}
         State: "{{state}}"
 

--- a/humilis_batch/resources.yaml.j2
+++ b/humilis_batch/resources.yaml.j2
@@ -110,15 +110,13 @@ resources:
                 {% endfor %}
             {% endif %}
 
-    {% if has_launch_template %}
+    {% if user_data %}
     LaunchTemplate:
       Type: "AWS::EC2::LaunchTemplate"
       Properties:
         LaunchTemplateName: "{{__context.environment.name}}-{{__context.layer.name}}-{{__context.stage}}"
         LaunchTemplateData:
-          {% if user_data %}
           UserData: {{user_data}}
-          {% endif %}
     {% endif %}
 
     ComputeEnvironment:
@@ -176,7 +174,7 @@ resources:
             {% if type == "SPOT" %}
             BidPercentage: {{bid_percentage}}
             {% endif %}
-            {% if has_launch_template %}
+            {% if user_data %}
             LaunchTemplate:
               LaunchTemplateId: {Ref: LaunchTemplate}
               Version:
@@ -228,6 +226,12 @@ resources:
                 {% for sg in security_group_ids %}
                 - {{sg}}
                 {% endfor %}
+            {% if user_data %}
+            LaunchTemplate:
+              LaunchTemplateId: {Ref: LaunchTemplate}
+              Version:
+                "Fn::GetAtt": ["LaunchTemplate", "LatestVersionNumber"]
+            {% endif %}
             Type: EC2
         State: "{{state}}"
     {% endif %}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,8 @@
 pytest
 mock
 tox
-
+boto3==1.12.23
+awscli==1.18.41
 humilis-vpc>=0.2.8
 
 -e .

--- a/tests/integration/config-init.service
+++ b/tests/integration/config-init.service
@@ -1,0 +1,10 @@
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="==MYBOUNDARY=="
+
+--==MYBOUNDARY==
+Content-Type: text/cloud-config; charset="us-ascii"
+
+runcmd:
+- echo "Test for humilis-batch with template! Encode me to base64"
+
+--==MYBOUNDARY==

--- a/tests/integration/humilis-batch.yaml.j2
+++ b/tests/integration/humilis-batch.yaml.j2
@@ -75,3 +75,26 @@ humilis-batch:
                     args:
                         - "bastion"
                 output_attribute: id
+
+        - layer: batch-with-launch-template
+          layer_type: batch
+          type: SPOT
+          allocation_strategy: BEST_FIT_PROGRESSIVE
+          subnet_ids:
+            - $layer_output:
+                layer_name: vpc
+                output_name: PublicSubnet1
+          vpc_id:
+            $layer_output:
+                layer_name: vpc
+                output_name: VpcId
+          ami_id:
+            $boto3:
+                service: ec2
+                call:
+                    method: get_ami_by_name
+                    args:
+                        - "bastion"
+                output_attribute: id
+          has_launch_template: yes
+          user_data: some-dummy-bas64-encoded-user-data

--- a/tests/integration/humilis-batch.yaml.j2
+++ b/tests/integration/humilis-batch.yaml.j2
@@ -97,4 +97,4 @@ humilis-batch:
                         - "bastion"
                 output_attribute: id
           has_launch_template: yes
-          user_data: some-dummy-bas64-encoded-user-data
+          user_data: TUlNRS1WZXJzaW9uOiAxLjAKQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PSI9PU1ZQk9VTkRBUlk9PSIKCi0tPT1NWUJPVU5EQVJZPT0KQ29udGVudC1UeXBlOiB0ZXh0L2Nsb3VkLWNvbmZpZzsgY2hhcnNldD0idXMtYXNjaWkiCgpydW5jbWQ6Ci0gZWNobyAiVGVzdCBmb3IgaHVtaWxpcy1iYXRjaCEiCgotLT09TVlCT1VOREFSWT09Cg==

--- a/tests/integration/humilis-batch.yaml.j2
+++ b/tests/integration/humilis-batch.yaml.j2
@@ -96,5 +96,5 @@ humilis-batch:
                     args:
                         - "bastion"
                 output_attribute: id
-          has_launch_template: yes
-          user_data: TUlNRS1WZXJzaW9uOiAxLjAKQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PSI9PU1ZQk9VTkRBUlk9PSIKCi0tPT1NWUJPVU5EQVJZPT0KQ29udGVudC1UeXBlOiB0ZXh0L2Nsb3VkLWNvbmZpZzsgY2hhcnNldD0idXMtYXNjaWkiCgpydW5jbWQ6Ci0gZWNobyAiVGVzdCBmb3IgaHVtaWxpcy1iYXRjaCEiCgotLT09TVlCT1VOREFSWT09Cg==
+
+          user_data: TUlNRS1WZXJzaW9uOiAxLjAKQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PSI9PU1ZQk9VTkRBUlk9PSIKCi0tPT1NWUJPVU5EQVJZPT0KQ29udGVudC1UeXBlOiB0ZXh0L2Nsb3VkLWNvbmZpZzsgY2hhcnNldD0idXMtYXNjaWkiCgpydW5jbWQ6Ci0gZWNobyAiVGVzdCBmb3IgaHVtaWxpcy1iYXRjaCB3aXRoIHRlbXBsYXRlISBFbmNvZGUgbWUgdG8gYmFzZTY0IgoKLS09PU1ZQk9VTkRBUlk9PQo=

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,12 @@
 skipsdist = True
 
 [testenv]
-passenv = DESTROY UPDATE AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID AWS_DEFAULT_REGION
+passenv =
+    DESTROY
+    UPDATE
+    AWS_SECRET_ACCESS_KEY
+    AWS_ACCESS_KEY_ID
+    AWS_DEFAULT_REGION
 commands = py.test tests/integration/
 deps = -r{toxinidir}/requirements-test.txt
 


### PR DESCRIPTION
#### Why?
We are seeking to create a sidecar in our batch compute environments. The sidecar could be used for different reasons. In this case, we are using it to monitor resource usage for the docker images that run in the compute environment. To do this, we are leveraging the `launch-template` and by extension `user-data` capabiility of AWS.

#### What?
Expose `user_data` as a plugin parameter for humilis-batch

#### How?
User-data can come in various forms (multi-line bash commands, cloud-init directives etc). We will use a common approach of accepting base64 configuration of the user-data.
